### PR TITLE
Adding reason phrase in ResponseData

### DIFF
--- a/lib/src/middleware/http_with_middleware.dart
+++ b/lib/src/middleware/http_with_middleware.dart
@@ -159,6 +159,7 @@ class HttpWithMiddleware {
             responseData.method.toString().substring(7),
             Uri.parse(responseData.url),
           ),
+          reasonPhrase: responseData.reasonPhrase,
         );
 
         return resultResponse as T;

--- a/lib/src/middleware/models/response_data.dart
+++ b/lib/src/middleware/models/response_data.dart
@@ -33,6 +33,7 @@ class ResponseData {
   int? contentLength;
   bool? isRedirect;
   bool? persistentConnection;
+  String? reasonPhrase;
 
   ResponseData({
     required this.method,
@@ -44,6 +45,7 @@ class ResponseData {
     this.contentLength,
     this.isRedirect,
     this.persistentConnection,
+    this.reasonPhrase,
   });
 
   factory ResponseData.fromHttpResponse(Response response) {
@@ -57,6 +59,7 @@ class ResponseData {
       url: response.request!.url.toString(),
       method: methodFromString(response.request!.method),
       persistentConnection: response.persistentConnection,
+      reasonPhrase: response.reasonPhrase,
     );
   }
 }


### PR DESCRIPTION
### reasonPhrase added in ResponseData
reasonPhrase (from Response object) can be useful when using a custom middleware (a subclass of `MiddlewareContract`)